### PR TITLE
fix: use typescript as input language

### DIFF
--- a/components/InputContainer.vue
+++ b/components/InputContainer.vue
@@ -6,7 +6,7 @@ import { code, config } from '~/state/bundler'
   <div flex="~ col">
     <CodeEditor
       v-model="code"
-      language="javascript"
+      language="typescript"
       input
       h-full
       min-h-0


### PR DESCRIPTION
Uses Typescript as language setting for monaco

## Current

<img width="353" alt="image" src="https://github.com/user-attachments/assets/a463d93e-27cc-421a-b56f-3ebac4000e17" />


## With PR

<img width="318" alt="image" src="https://github.com/user-attachments/assets/3a04c103-5522-43b6-b9ad-70c1d15808c6" />
