### PR TITLE
feat: show bundler version

### DIFF
--- a/components/navbar/BundlerSelect.vue
+++ b/components/navbar/BundlerSelect.vue
@@ -7,7 +7,7 @@ import { currentBundler } from '~/state/bundler'
   <div>
     <select v-model="currentBundler">
       <option v-for="bundler of bundlers" :key="bundler.id" :value="bundler.id">
-        {{ bundler.name }}
+        {{ bundler.name }} v{{ bundler.version }}
       </option>
     </select>
   </div>

--- a/composables/bundlers/esbuild.ts
+++ b/composables/bundlers/esbuild.ts
@@ -1,4 +1,4 @@
-import { build, initialize } from 'esbuild-wasm'
+import { build, initialize, version } from 'esbuild-wasm'
 import wasmURL from 'esbuild-wasm/esbuild.wasm?url'
 import type { Bundler } from './index'
 
@@ -6,6 +6,7 @@ export const esbuild: Bundler<undefined> = {
   id: 'esbuild',
   name: 'esbuild',
   icon: 'i-logos:esbuild',
+  version,
   pkgName: 'esbuild-wasm',
   async init() {
     await initialize({ wasmURL })

--- a/composables/bundlers/index.ts
+++ b/composables/bundlers/index.ts
@@ -8,6 +8,7 @@ export interface Bundler<T = void> {
   name: string
   icon: string
   pkgName: string
+  version: string,
   webContainer?: boolean
 
   init?: () => Awaitable<T>

--- a/composables/bundlers/rolldown.ts
+++ b/composables/bundlers/rolldown.ts
@@ -1,5 +1,6 @@
 import {
   rolldown as build,
+  VERSION as version,
   type LogLevel,
   type RollupLog,
 } from '@rolldown/browser'
@@ -9,6 +10,7 @@ export const rolldown: Bundler = {
   id: 'rolldown',
   name: 'Rolldown',
   icon: 'i-logos:rolldown',
+  version,
   pkgName: 'i-vscode-icons:file-type-rolldown',
   async build(code, options) {
     const entry = '/virtual-entry.ts'

--- a/composables/bundlers/rollup.ts
+++ b/composables/bundlers/rollup.ts
@@ -1,12 +1,13 @@
 // @ts-expect-error missing types
 import { transform as oxcTransform } from '@oxc-transform/binding-wasm32-wasi'
-import { rollup as build, type LogLevel, type RollupLog } from '@rollup/browser'
+import { rollup as build, VERSION as version, type LogLevel, type RollupLog } from '@rollup/browser'
 import type { Bundler } from './index'
 
 export const rollup: Bundler = {
   id: 'rollup',
   name: 'Rollup',
   icon: 'i-logos:rollupjs',
+  version,
   pkgName: '@rollup/browser',
   async build(code, config) {
     const entry = '_virtual-entry.ts'


### PR DESCRIPTION
### Description

Adds the version of the used bundler. Especially helpful for Rolldown as new versions are shipping pretty fast 🔥

Probably could be displayed nicer though
